### PR TITLE
Make vars dynamic where necessary

### DIFF
--- a/src/osc.clj
+++ b/src/osc.clj
@@ -116,7 +116,7 @@
 
 ;; We use binding to *osc-msg-bundle* to bundle messages
 ;; and send combined with an OSC timestamp.
-(def *osc-msg-bundle* nil)
+(def ^{:dynamic true} *osc-msg-bundle* nil)
 
 (defn osc-send-msg
   "Send OSC msg to peer."

--- a/src/osc/internals.clj
+++ b/src/osc/internals.clj
@@ -202,9 +202,9 @@
     (.start t)
     t))
 
-(declare *osc-handlers*)
-(declare *current-handler*)
-(declare *current-path*)
+(declare ^{:dynamic true} *osc-handlers*)
+(declare ^{:dynamic true} *current-handler*)
+(declare ^{:dynamic true} *current-path*)
 
 (defn- msg-handler-dispatcher [handlers]
   (fn [msg]


### PR DESCRIPTION
In order for this to work with clojure 1.3 (at any point in future), add ^{:dynamic true} before any var which is to be rebound at some point. This patch will do just that.
