### PR TITLE
Fix race condition between socket bind and receive

### DIFF
--- a/src/overtone/osc/peer.clj
+++ b/src/overtone/osc/peer.clj
@@ -146,6 +146,8 @@
   messages. Recieves packets from chan using buf and then handles them either
   as messages or bundles - passing the source information and message itself."
   [chan buf running? all-listeners]
+  (while (not (.isBound (.socket chan)))
+    (Thread/sleep 1))
   (try
     (while @running?
       (try


### PR DESCRIPTION
When booting SuperCollider (external or internal), the DatagramChannel used for communication is created by the (peer) function. A thread is spawned to receive data on the channel, and the main thread goes on to bind the channel's socket to a local IP endpoint. There is a race condition here that consistently broke Overtone on my Windows 7 x64 machine - the first call to receive happened before the bind, causing everything to hang with no exceptions thrown.

Modified (listen-loop) to wait until the socket is bound to a local IP endpoint before attempting to receive. This fixes the race condition due to bind and receive happening on different threads.
